### PR TITLE
Align description and link target

### DIFF
--- a/src/handlebars/index.hbs
+++ b/src/handlebars/index.hbs
@@ -78,7 +78,7 @@
         <p class="section-description">
           O FloripaJS é uma comunidade formada em 2012 por um grupo de amigos que queriam fomentar o desenvolvimento front-end em Florianópolis e região. No ano seguinte o grupo começou a fazer reuniões e encontros pela internet. Mas foi apenas em 2014 que o grupo ganhou força devido ao meetup que ocorre frequentemente. Hoje o FloripaJS é uma das comunidades mais ativas do Brasil, graças ao seu público fiel nos encontros e também no apoio ao mundo open-source. 
         </p>
-        <a class="button button-slack" href="#">
+        <a class="button button-slack" href="{{ config.social.slack }}" target="_blank">
           Slack.floripajs.org
         </a>
       </div>

--- a/src/handlebars/index.hbs
+++ b/src/handlebars/index.hbs
@@ -107,7 +107,7 @@
         <p class="section-description">
           Como forma de retribuir a comunidade tudo aquilo que usamos hoje, temos uma organização no <strong>Github</strong> para nossos projetos open-source. Precisamos de um time grande e forte, para assim criar novos projetos e dar manutenção nos já existentes. Se você deseja <strong>contribuir</strong> com nossos projetos, trazer um projeto novo para nossa organização ou somente fazer parte do time, entre em contato com alguns dos <a href="https://github.com/orgs/floripajs/people" target="_blank">devs que lá estão</a> ou pelo e-mail <a href="mailto:contato@floripajs.org">contato@floripajs.org</a> =]
         </p>
-        <a class="button button-github" href="{{ config.social.github }}">
+        <a class="button button-github" href="{{ config.social.github }}" target="_blank">
           github.com/floripajs
         </a>
       </div>
@@ -122,7 +122,7 @@
           <img class="section-image" src="assets/img/videos.jpg" />
           Gostamos muito de compartilhar conteúdo em vídeo. Por conta disso, todos nossos meetups são transmitidos ao vivo pelo nosso <a href="{{ config.social.youtube }}">Canal do Youtube</a>. Também fazemos a cobertura de alguns eventos entrevistando os participantes e fazendo algumas resenhas sobre as palestras. Acesse nosso canal e confira todas nossas coberturas e meetups!
         </p>
-        <a class="button button-youtube" href="#">
+        <a class="button button-youtube" href="{{ config.social.youtube }}" target="_blank">
           youtube.com/floripajs
         </a>
       </div>

--- a/src/stylus/_base/layout.styl
+++ b/src/stylus/_base/layout.styl
@@ -210,7 +210,6 @@ body
   font-size 1.6rem
   line-height 2
   margin-bottom 2em
-  text-align: justify;
 
   +below($phone)
     font-size 1.4rem

--- a/src/stylus/_base/layout.styl
+++ b/src/stylus/_base/layout.styl
@@ -210,6 +210,7 @@ body
   font-size 1.6rem
   line-height 2
   margin-bottom 2em
+  text-align: justify;
 
   +below($phone)
     font-size 1.4rem


### PR DESCRIPTION
This branch contains:
- Page Descriptions align as justify;
- Included the target property as blank in the main links of descriptions for the user not be redirect in the same tab.